### PR TITLE
Add ValidateWithContext schema method to pass context.Context

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1,6 +1,7 @@
 package jsonschema
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -852,7 +853,7 @@ func (c *Compiler) validateSchema(r *resource, v interface{}, vloc string) error
 	}
 
 	validate := func(meta *Schema) error {
-		return meta.validateValue(v, v, vloc, NewParentDescriptor(nil, nil))
+		return meta.validateValue(context.TODO(), v, v, vloc, NewParentDescriptor(nil, nil))
 	}
 
 	meta := r.draft.meta

--- a/extension.go
+++ b/extension.go
@@ -91,7 +91,7 @@ func (ctx CompilerContext) GetResourceSchema() *Schema {
 
 // ValidationContext provides additional context required in validating for extension.
 type ValidationContext struct {
-	ctx             context.Context
+	externalContext context.Context
 	result          validationResult
 	doc             interface{}
 	vloc            string
@@ -144,6 +144,11 @@ func (ctx ValidationContext) GetDoc() interface{} {
 // GetParent returns the parent descriptor of the value being validated.
 func (ctx ValidationContext) GetParent() ParentDescriptor {
 	return ctx.parent
+}
+
+// GetExternalContext returns the external context supplied by user.
+func (ctx ValidationContext) GetExternalContext() context.Context {
+	return ctx.externalContext
 }
 
 // Group is used by extensions to group multiple errors as causes to parent error.

--- a/extension.go
+++ b/extension.go
@@ -1,5 +1,7 @@
 package jsonschema
 
+import "context"
+
 // ExtCompiler compiles custom keyword(s) into ExtSchema.
 type ExtCompiler interface {
 	// Compile compiles the custom keywords in schema m and returns its compiled representation.
@@ -89,6 +91,7 @@ func (ctx CompilerContext) GetResourceSchema() *Schema {
 
 // ValidationContext provides additional context required in validating for extension.
 type ValidationContext struct {
+	ctx             context.Context
 	result          validationResult
 	doc             interface{}
 	vloc            string


### PR DESCRIPTION
Adding new schema  method `ValidateWithContext` so we can pass context.Context to schema validation code, so it can be used to send storage structure pointers to schema extensions to extract extension state accross the API boundary.